### PR TITLE
non-interactive path fix for shims and rbenv init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ RUN rbenv global ${RUBY_VERSION} && rbenv rehash
 RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 RUN echo 'eval "$(rbenv init -)"' >> ~/.profile
 
+# skip the documentation
+RUN echo 'gem: --no-document' >> ~/.gemrc
+
+# Setting shim path due to non-interactive bash sessions not running rbenv init
+ENV PATH=/root/.rbenv/shims:$PATH
+
 RUN gem install bundler --version=2.1.4
 
 # add the node repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN rbenv global ${RUBY_VERSION} && rbenv rehash
 RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 RUN echo 'eval "$(rbenv init -)"' >> ~/.profile
 
-# skip the documentation
-RUN echo 'gem: --no-document' >> ~/.gemrc
-
 # Setting shim path due to non-interactive bash sessions not running rbenv init
 ENV PATH=/root/.rbenv/shims:$PATH
 


### PR DESCRIPTION
# Description of change

CI/CD was failing to find the `bundle` command when using the container.  I believe it was running commands non-interactively without a login so whatever magic `rbenv init -` does to update the path etc was not happening for it causing it to fail.

Rather than prefix all commands with: `/root/.rbenv/shims/bundle`, add the shim path to the PATH.

I dug into the BASH_ENV and read up on the different kinds of prompts.  Tried a bunch of things but none seemed to work.

## Testing Performed
With a locally built image...

Before
```shell
docker run rewindio/docker-amazonlinux2-ruby:latest gem
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "gem": executable file not found in $PATH: unknown.
```

After

```shell
docker run rewindio/docker-amazonlinux2-ruby:latest gem
RubyGems is a sophisticated package manager for Ruby.  This is a
basic help message containing pointers to more information.
```
