### PR TITLE
add ruby version 2.6.8

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         ruby_version: [
           2.6.7,
+          2.6.8,
           2.7.4
         ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description of change

add build workflow to accommodate EB platform update from 3.3.2 -> 3.3.4 which ups ruby version 2.6.7 to 2.6.8