### PR TITLE
Update ca-certificates to remove DST Root CA X3

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -6,9 +6,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+
     steps:
-
-      - uses: actions/checkout@v2
-
-      - name: Run hadolint
-        run: hadolint Dockerfile
+      - uses: actions/checkout@v2 
+      - uses: hadolint/hadolint-action@v1.5.0
+        with:
+          dockerfile: Dockerfile

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,14 @@
+name: Lint
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Run hadolint
+        run: hadolint Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux:2.0.20211001.0@sha256:28091ca56cd22253c7a5e99cb581dacee6678181208e2a7799d573bf25d51a63
 
 ARG RUBY_VERSION
-ARG NODEJS_VERSION=10
+ARG NODEJS_VERSION=14
 
 LABEL org.opencontainers.image.source https://github.com/rewindio/docker-amazonlinux2-ruby
 LABEL maintainer "Rewind DevOps <devops@rewind.io>"
@@ -12,25 +12,24 @@ RUN curl -sL https://rpm.nodesource.com/setup_"${NODEJS_VERSION}".x | bash - && 
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y \
       bzip2-1.* \
-      gcc-7 \
-      gcc-6 \
       gcc-c++-7.* \
       gdbm-devel-1.13* \
       git-2.* \
       libffi-devel-3.* \
       libyaml-devel-0.* \
-      make-3.8* \
+      make-3* \
       ncurses-devel-6.* \
-      nodejs-${NODEJS_VERSION} \
+      nodejs-${NODEJS_VERSION}.* \
       openssl-devel-1.0.2k-* \
-      postgresql-devel-9.2.* \
+      postgresql-devel-9.* \
       readline-devel-6.2* \
       tar-1.26* \
-      which-20* \
-      yarn-22* \
+      which-2.20* \
+      yarn-1.22* \
       zip-3.0* \
       zlib-devel-1.2.* && \
     yum clean all && \
+    rm -rf /var/cache/yum && \
     # rbenv
     git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
     git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2@sha256:1928c652007d27f087f43e3d652b51415b6751a10d522593166946f110a3be39
+FROM amazonlinux:2.0.20211001.0@sha256:28091ca56cd22253c7a5e99cb581dacee6678181208e2a7799d573bf25d51a63
 
 ARG RUBY_VERSION
 ARG NODEJS_VERSION=10
@@ -11,17 +11,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sL https://rpm.nodesource.com/setup_"${NODEJS_VERSION}".x | bash - && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y \
-      bzip2-1.0.* \
-      gcc-7.3.* \
+      bzip2-1.* \
+      gcc-7 \
       gcc-6 \
-      gcc-c++-7.3.* \
+      gcc-c++-7.* \
       gdbm-devel-1.13* \
-      git-2.32.* \
-      libffi-devel-3.0.* \
-      libyaml-devel-0.1.4.* \
-      make-3.82* \
-      ncurses-devel-6.0.* \
-      nodejs-10.* \
+      git-2.* \
+      libffi-devel-3.* \
+      libyaml-devel-0.* \
+      make-3.8* \
+      ncurses-devel-6.* \
+      nodejs-${NODEJS_VERSION} \
       openssl-devel-1.0.2k-* \
       postgresql-devel-9.2.* \
       readline-devel-6.2* \
@@ -47,10 +47,3 @@ RUN rbenv install ${RUBY_VERSION} && \
 ENV PATH=/root/.rbenv/shims:$PATH
 
 RUN gem install bundler --version=2.1.4
-
-# Blacklist DST Root CA X3
-# https://blog.devgenius.io/rhel-centos-7-fix-for-lets-encrypt-change-8af2de587fe4
-# https://github.com/mperham/sidekiq/issues/5008
-RUN trust dump --filter "pkcs11:id=%C4%A7%B1%A4%7B%2C%71%FA%DB%E1%4B%90%75%FF%C4%15%60%85%89%10;type=cert" \
-    > /etc/pki/ca-trust/source/blacklist/dst-root.p11-kit && \
-    update-ca-trust extract

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,55 @@
+FROM amazonlinux:2@sha256:1928c652007d27f087f43e3d652b51415b6751a10d522593166946f110a3be39
+
 ARG RUBY_VERSION
 ARG NODEJS_VERSION=10
-
-FROM amazonlinux:2
 
 LABEL org.opencontainers.image.source https://github.com/rewindio/docker-amazonlinux2-ruby
 LABEL maintainer "Rewind DevOps <devops@rewind.io>"
 
-RUN yum update -y -q && yum install -y -q git which zip tar gcc-6 bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel gcc-c++ gcc make postgresql-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-
-RUN git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-
-SHELL ["/bin/bash", "-l", "-c"]
+RUN curl -sL https://rpm.nodesource.com/setup_"${NODEJS_VERSION}".x | bash - && \
+    curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    yum install -y \
+      bzip2 \
+      gcc \
+      gcc-6 \
+      gcc-c++ \
+      gdbm-devel \
+      git \
+      libffi-devel \
+      libyaml-devel \
+      make \
+      ncurses-devel \
+      nodejs \
+      openssl-devel \
+      postgresql-devel \
+      readline-devel \
+      tar \
+      which \
+      yarn \
+      zip \
+      zlib-devel && \
+    yum clean all && \
+    # rbenv
+    git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
+    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 
 ENV PATH=/root/.rbenv/bin:/root/.rbenv/plugins/ruby-build/bin:$PATH
 
-ARG RUBY_VERSION
-RUN rbenv install ${RUBY_VERSION}
-RUN rbenv global ${RUBY_VERSION} && rbenv rehash
-
-RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-RUN echo 'eval "$(rbenv init -)"' >> ~/.profile
+RUN rbenv install ${RUBY_VERSION} && \
+      rbenv global ${RUBY_VERSION} && \
+      rbenv rehash && \
+      echo "eval \"$(rbenv init -)\"" >> ~/.bashrc && \
+      echo "eval \"$(rbenv init -)\"" >> ~/.profile
 
 # Setting shim path due to non-interactive bash sessions not running rbenv init
 ENV PATH=/root/.rbenv/shims:$PATH
 
 RUN gem install bundler --version=2.1.4
 
-# add the node repo
-ARG NODEJS_VERSION
-RUN curl -sL https://rpm.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
-# add the yarn repo
-RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
-
-#install node10 and yarn
-RUN yum install -y -q nodejs yarn
+# Blacklist DST Root CA X3
+# https://blog.devgenius.io/rhel-centos-7-fix-for-lets-encrypt-change-8af2de587fe4
+# https://github.com/mperham/sidekiq/issues/5008
+RUN trust dump --filter "pkcs11:id=%C4%A7%B1%A4%7B%2C%71%FA%DB%E1%4B%90%75%FF%C4%15%60%85%89%10;type=cert" > /etc/pki/ca-trust/source/blacklist/dst-root.p11-kit \
+    && update-ca-trust extract

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,25 +11,25 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sL https://rpm.nodesource.com/setup_"${NODEJS_VERSION}".x | bash - && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y \
-      bzip2 \
-      gcc \
+      bzip2-1.0.* \
+      gcc-7.3.* \
       gcc-6 \
-      gcc-c++ \
-      gdbm-devel \
-      git \
-      libffi-devel \
-      libyaml-devel \
-      make \
-      ncurses-devel \
-      nodejs \
-      openssl-devel \
-      postgresql-devel \
-      readline-devel \
-      tar \
-      which \
-      yarn \
-      zip \
-      zlib-devel && \
+      gcc-c++-7.3.* \
+      gdbm-devel-1.13* \
+      git-2.32.* \
+      libffi-devel-3.0.* \
+      libyaml-devel-0.1.4.* \
+      make-3.82* \
+      ncurses-devel-6.0.* \
+      nodejs-10.* \
+      openssl-devel-1.0.2k-* \
+      postgresql-devel-9.2.* \
+      readline-devel-6.2* \
+      tar-1.26* \
+      which-20* \
+      yarn-22* \
+      zip-3.0* \
+      zlib-devel-1.2.* && \
     yum clean all && \
     # rbenv
     git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
@@ -38,10 +38,10 @@ RUN curl -sL https://rpm.nodesource.com/setup_"${NODEJS_VERSION}".x | bash - && 
 ENV PATH=/root/.rbenv/bin:/root/.rbenv/plugins/ruby-build/bin:$PATH
 
 RUN rbenv install ${RUBY_VERSION} && \
-      rbenv global ${RUBY_VERSION} && \
-      rbenv rehash && \
-      echo "eval \"$(rbenv init -)\"" >> ~/.bashrc && \
-      echo "eval \"$(rbenv init -)\"" >> ~/.profile
+    rbenv global ${RUBY_VERSION} && \
+    rbenv rehash && \
+    echo "eval $(rbenv init -)" >> ~/.bashrc && \
+    echo "eval $(rbenv init -)" >> ~/.profile
 
 # Setting shim path due to non-interactive bash sessions not running rbenv init
 ENV PATH=/root/.rbenv/shims:$PATH
@@ -51,5 +51,6 @@ RUN gem install bundler --version=2.1.4
 # Blacklist DST Root CA X3
 # https://blog.devgenius.io/rhel-centos-7-fix-for-lets-encrypt-change-8af2de587fe4
 # https://github.com/mperham/sidekiq/issues/5008
-RUN trust dump --filter "pkcs11:id=%C4%A7%B1%A4%7B%2C%71%FA%DB%E1%4B%90%75%FF%C4%15%60%85%89%10;type=cert" > /etc/pki/ca-trust/source/blacklist/dst-root.p11-kit \
-    && update-ca-trust extract
+RUN trust dump --filter "pkcs11:id=%C4%A7%B1%A4%7B%2C%71%FA%DB%E1%4B%90%75%FF%C4%15%60%85%89%10;type=cert" \
+    > /etc/pki/ca-trust/source/blacklist/dst-root.p11-kit && \
+    update-ca-trust extract

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # docker-amazonlinux2-ruby
-Docker image(s) running either Ruby 2.6 or 2.7, NodeJS 10 on Amazonlinux 2 as root.
+
+> :information_source: These images are intended for development, not production
+
+These container images based on Amazon Linux 2.
+
+Ruby and NodeJS are installed on the image, a long with other common tools for development.
+
+ It currently builds and publishes the following to dockerhub:
+ - `rewindio/docker-amazonlinux2-ruby:2.6.7`
+ - `rewindio/docker-amazonlinux2-ruby:2.6.8`
+ - `rewindio/docker-amazonlinux2-ruby:2.7.4`

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > :information_source: These images are intended for development, not production
 
-These container images based on Amazon Linux 2.
+These container images are based on [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/).
 
-Ruby and NodeJS are installed on the image, a long with other common tools for development.
+Ruby and nodejs are installed on the images, along with other common tools for development.
 
  It currently builds and publishes the following to dockerhub:
  - `rewindio/docker-amazonlinux2-ruby:2.6.7`


### PR DESCRIPTION
# Description of change

A root cert for Let's Encrypt [expired yesterday](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/). 

~This change blacklists the expired root cert, so the newer one is used.~ This is no longer required. We only need to update the `ca-certificates` package now.

> Major Updates: Update of ca-certificates to version 2021.2.50-72.amzn2.0.1 addresses the expiring IdentTrust DST Root CA X3, which affected some Let’s Encrypt TLS certificates. The effect of the expiring certificate would be an inability of OpenSSL to validate impacted certificates issued by Let’s Encrypt. Impacted customers may have experienced connection or certificate errors when attempting to connect to certain websites or APIs that use Let's Encrypt certificates.

https://aws.amazon.com/amazon-linux-2/release-notes/

https://github.com/mperham/sidekiq/issues/5008

Also:
- Refactor Dockerfile to use less layers as recommended by Hadolint
- Add Hadolint GitHub action

## Testing Performed

Built and tested locally.