### PR TITLE
Add ruby 2.7.6 to deploy matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ jobs:
           2.6.9,
           2.7.4,
           2.7.5,
+          2.7.6,
           3.0.3
         ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description of change

- Add ruby 2.7.6 to deploy version matrix.
- EBS platform version 3.4.5 runs Ruby 2.7.6 which is a minor version upgrade from 2.7.5 
https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.ruby

## Testing Performed

If you had to test this manually, some quick notes on how you tested.  If automated testing is expected to cover this, which test cases cover this change (or do new ones need to be added)
