### PR TITLE
add ruby 3.0.4 for ultron

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,8 @@ jobs:
           2.7.4,
           2.7.5,
           2.7.6,
-          3.0.3
+          3.0.3,
+          3.0.4
         ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description of change

- Ultron is upgrading to ruby 3.0.4. Adding ruby 3.0.4 to deploy matrix to create container
## Testing Performed

If you had to test this manually, some quick notes on how you tested.  If automated testing is expected to cover this, which test cases cover this change (or do new ones need to be added)
